### PR TITLE
Global Registry (alternative option)

### DIFF
--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -127,6 +127,7 @@ TODO: to be completed
 * The role of the Global Registry is to make available the information required for Global Services and WIS nodes to connect with each other. 
 * The Global Registry makes available to Global Brokers the list of registered WIS Nodes. The following metadata is made available for each WIS Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
 * The Global Registry issues X.509 certificates to all GBs and GCs and periodically renews them.
+* The Global Registry makes available to WIS nodes the (public) CA certificate used to issue the certificates to GBs/GCs.
 * The Global Registry maintains a certificate revokation list.
 * The Global Registry makes information available in such a way that minimizes the downtime of WIS nodes in case of changes to a node's metadata.
 

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -39,7 +39,7 @@ TODO: to be completed
 
 ==== Practices and procedures
 
-The following procedures will be described here once validated through testing during the WIS pilot phase:
+The following procedures will be described here once validated through testing during the WIS2 pilot phase:
 
 * Assigning a Global Broker to a NC or DCPC
 * Alerting originating NC or DCPC about malformed or non-compliant messages

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -123,10 +123,10 @@ TODO: to be completed
 
 === Global Registry ===
 
-* The role of the Global Registry is to make available the information required for Global Infrastructure and WIS nodes to connect with each other. 
-* The Global Registry makes available to Global Caches the list of registered WIS Nodes. The following metadata is made available for each WIS Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
+* The role of the Global Registry is to make available the information required for Global Services and WIS nodes to connect with each other. 
+* The Global Registry makes available to Global Brokers the list of registered WIS Nodes. The following metadata is made available for each WIS Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
 * The Global Registry makes available to WIS nodes the list of IP addresses used by Global Brokers and Global Caches to subscribe to and download data from WIS nodes.
-* The Global Registry provides authorized contacts the means to update information about their WIS Node or Global Infrastrucure.
+* The Global Registry provides authorized contacts the means to update information about their WIS Node or Global Services.
 * The Global Registry makes information available in such a way that minimizes the downtime of WIS nodes in case of changes to a node's metadata.
 
 ==== Service level

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -117,3 +117,12 @@ TODO: to be completed
 Procedures pertinent to the Global Monitor will be described here once validated through testing during the WIS2 pilot phase.
 
 TODO: to be completed
+
+=== Global Registry ===
+
+* The roles of the Global Registry is to make available the information required for Global Infrastructure and WIS2 nodes to connect with each other. 
+* The Global Registry makes available to Global Caches the list of registered WIS2 Nodes. The following metadata is made available for each WIS2 Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
+* The Global Registry makes available to WIS2 nodes the list of IP addresses used by Global Brokers and Global Caches to subscribe to and download data from WIS2 nodes.
+* The Global Registry provides authorized contacts the means to update information about their WIS2 Node or Global Infrastrucure.
+* The Global Registry makes information available in such a way that minimizes the downtime of WIS2 nodes in case of changes to a node's metadata.
+* The Global Registry is a non-operational service. Nodes obtaining information from the Global Registry shall make provisions to keep operating without the Global Registry for at least 14 days.

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -120,9 +120,12 @@ TODO: to be completed
 
 === Global Registry ===
 
-* The roles of the Global Registry is to make available the information required for Global Infrastructure and WIS2 nodes to connect with each other. 
+* The role of the Global Registry is to make available the information required for Global Infrastructure and WIS2 nodes to connect with each other. 
 * The Global Registry makes available to Global Caches the list of registered WIS2 Nodes. The following metadata is made available for each WIS2 Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
 * The Global Registry makes available to WIS2 nodes the list of IP addresses used by Global Brokers and Global Caches to subscribe to and download data from WIS2 nodes.
 * The Global Registry provides authorized contacts the means to update information about their WIS2 Node or Global Infrastrucure.
 * The Global Registry makes information available in such a way that minimizes the downtime of WIS2 nodes in case of changes to a node's metadata.
+
+==== Service level
+
 * The Global Registry is a non-operational service. Nodes obtaining information from the Global Registry shall make provisions to keep operating without the Global Registry for at least 14 days.

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -32,8 +32,8 @@ TODO: to be completed
 * A Global Broker is built around two software components:
 ** An off the shelf broker implementing both MQTT 3.1.1 and MQTT 5.0 in a highly-available setup (cluster)Tools such as EMQX, HiveMQ, VerneMQ are compliant with these requirements.
 ** Additional features (anti-loop, message format compliance,…) are required. An open source implementation will be made available during the pilot phase.
-* When establishing a TLS connection to a WIS2 node, the Global Broker shall use the certificate issued by the Global Registry as a client certificate. 
-* When establishing a TLS connection to a WIS2 node, the Global Broker should validate the WIS2 node server certificate and check that it matches the hostname. 
+* When establishing a TLS connection to a WIS node, the Global Broker shall use the certificate issued by the Global Registry as a client certificate. 
+* When establishing a TLS connection to a WIS node, the Global Broker should validate the server certificate and check that it matches the hostname. 
 
 TODO: to be completed
 
@@ -62,8 +62,8 @@ TODO: to be completed
 * A Global Cache will store a full set of discovery metadata records. This is not an additional metadata catalogue that Data Consumers can search and browse – it provides a complete set of discovery metadata records to support populating a Global Discovery Catalogue instance.
 * A Global Cache is designed to support real-time distribution of content. Data Consumers access data objects from a Global Cache instance by resolving the URL in a "data availability" notification message and downloading the file. 
 * There is no requirement for a Global Cache to provide a "browse-able" interface to the files in its repository allowing Data Consumers to discover what content is available. However, a Global Cache may choose to provide such a capability (e.g., implemented as a "Web Accessible Folder", or WAF) along with adequate documentation for Data Consumers to understand how the capability works.
-* When establishing a TLS connection to a WIS2 node, the Global Cache shall use the certificate issued by the Global Registry as a client certificate. 
-* When establishing a TLS connection to a WIS2 node, the Global Cache should validate the WIS2 node server certificate and check that it matches the hostname.
+* When establishing a TLS connection to a WIS node, the Global Cache shall use the certificate issued by the Global Registry as a client certificate. 
+* When establishing a TLS connection to a WIS node, the Global Cache should validate the server certificate and check that it matches the hostname.
 
 TODO: to be completed
 

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -62,7 +62,7 @@ TODO: to be completed
 * A Global Cache will store a full set of discovery metadata records. This is not an additional metadata catalogue that Data Consumers can search and browse – it provides a complete set of discovery metadata records to support populating a Global Discovery Catalogue instance.
 * A Global Cache is designed to support real-time distribution of content. Data Consumers access data objects from a Global Cache instance by resolving the URL in a "data availability" notification message and downloading the file. 
 * There is no requirement for a Global Cache to provide a "browse-able" interface to the files in its repository allowing Data Consumers to discover what content is available. However, a Global Cache may choose to provide such a capability (e.g., implemented as a "Web Accessible Folder", or WAF) along with adequate documentation for Data Consumers to understand how the capability works.
-* A Global Cache maintains the list of IP addresses used for outgoing subscription connections to WIS2 nodes in the Global Registry. The Global Cache must announce changes to these IP addresses at least one month before implementing these changes.
+* A Global Cache maintains the list of IP addresses used for outgoing connections to WIS2 nodes in the Global Registry. The Global Cache must announce changes to these IP addresses at least one month before implementing these changes.
 
 TODO: to be completed
 

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -21,6 +21,8 @@ TODO: to be completed
 * There will be multiple Global Broker instances to ensure highly available, low latency global provision of messages within WIS.
 * A Global Broker instance subscribes to messages from NC/DCPCs and other Global Brokers
 * A Global Broker instance will subscribe to messages from a subset of NC/DCPCs and republish them.
+** A Global Broker obtains the following list of metadata fields for each of the WIS2 nodes in the subset of NC/DCPCs covered by this Global Broker, from the Global Registry: Hostname and port(s) of broker, center_id, list of supported protocols (MQTT, MQTTs, web-socket). 
+** A Global Broker uses the username/password combination "everyone/everyone" to subscribe to the topic corresponding to the WIS2 node using one of the supported protocols.
 * At least one Global Broker will subscribe to messages from every NC/DCPC.
 * For full global coverage, a Global Broker instance will subscribe to messages from other Global Broker instances and republish them.
 * A Global Broker instance will republish a message only once – noting that a particular message may be received multiple times (e.g., from different sources). Discarding duplicate messages is referred to as "anti-loop".
@@ -31,7 +33,7 @@ TODO: to be completed
 * A Global Broker is built around two software components:
 ** An off the shelf broker implementing both MQTT 3.1.1 and MQTT 5.0 in a highly-available setup (cluster)Tools such as EMQX, HiveMQ, VerneMQ are compliant with these requirements.
 ** Additional features (anti-loop, message format compliance,…) are required. An open source implementation will be made available during the pilot phase.
-
+* A Global Broker maintains the list of IP addresses used for outgoing subscription connections to WIS2 nodes in the Global Registry. The Global Broker must announce changes to these IP addresses at least one month before implementing these changes.
 
 TODO: to be completed
 
@@ -60,6 +62,7 @@ TODO: to be completed
 * A Global Cache will store a full set of discovery metadata records. This is not an additional metadata catalogue that Data Consumers can search and browse – it provides a complete set of discovery metadata records to support populating a Global Discovery Catalogue instance.
 * A Global Cache is designed to support real-time distribution of content. Data Consumers access data objects from a Global Cache instance by resolving the URL in a "data availability" notification message and downloading the file. 
 * There is no requirement for a Global Cache to provide a "browse-able" interface to the files in its repository allowing Data Consumers to discover what content is available. However, a Global Cache may choose to provide such a capability (e.g., implemented as a "Web Accessible Folder", or WAF) along with adequate documentation for Data Consumers to understand how the capability works.
+* A Global Cache maintains the list of IP addresses used for outgoing subscription connections to WIS2 nodes in the Global Registry. The Global Cache must announce changes to these IP addresses at least one month before implementing these changes.
 
 TODO: to be completed
 

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -22,8 +22,7 @@ TODO: to be completed
 * A Global Broker instance subscribes to messages from NC/DCPCs and other Global Brokers
 * A Global Broker instance will subscribe to messages from a subset of NC/DCPCs and republish them.
 ** A Global Broker obtains the following list of metadata fields for each of the WIS nodes in the subset of NC/DCPCs covered by this Global Broker, from the Global Registry: Hostname and port(s) of broker, center_id, list of supported protocols (MQTT, MQTTs, web-socket). 
-** A Global Broker uses the username/password combination "everyone/everyone" to subscribe to the topic corresponding to the WIS node using one of the supported protocols.
-* At least one Global Broker will subscribe to messages from every NC/DCPC.
+* At least two Global Brokers will subscribe to messages from every NC/DCPC.
 * For full global coverage, a Global Broker instance will subscribe to messages from other Global Broker instances and republish them.
 * A Global Broker instance will republish a message only once – noting that a particular message may be received multiple times (e.g., from different sources). Discarding duplicate messages is referred to as "anti-loop".
 * It is not required that a Global Broker instance republishes messages from all other Global Brokers (e.g., establishing ‘fully meshed’ connection). However, it is essential that messages propagate through WIS efficiently and effectively, from originating NC/DCPC to Data Consumers in all Regions. Consequently, it is recommended that topological distance between every Global Broker shall not exceed 3 "hops"  (i.e., a message received at a Global Broker shall be republished by no more than 3 other Global Brokers on its route from the originating NC/DCPC). Connectivity between Global Brokers will be recommended by Experts from INFCOM/SC-IMT. 
@@ -33,7 +32,8 @@ TODO: to be completed
 * A Global Broker is built around two software components:
 ** An off the shelf broker implementing both MQTT 3.1.1 and MQTT 5.0 in a highly-available setup (cluster)Tools such as EMQX, HiveMQ, VerneMQ are compliant with these requirements.
 ** Additional features (anti-loop, message format compliance,…) are required. An open source implementation will be made available during the pilot phase.
-* A Global Broker maintains the list of IP addresses used for outgoing subscription connections to WIS nodes in the Global Registry. The Global Broker must announce changes to these IP addresses at least one month before implementing these changes.
+* When establishing a TLS connection to a WIS2 node, the Global Broker shall use the certificate issued by the Global Registry as a client certificate. 
+* When establishing a TLS connection to a WIS2 node, the Global Broker should validate the WIS2 node server certificate and check that it matches the hostname. 
 
 TODO: to be completed
 
@@ -62,7 +62,8 @@ TODO: to be completed
 * A Global Cache will store a full set of discovery metadata records. This is not an additional metadata catalogue that Data Consumers can search and browse – it provides a complete set of discovery metadata records to support populating a Global Discovery Catalogue instance.
 * A Global Cache is designed to support real-time distribution of content. Data Consumers access data objects from a Global Cache instance by resolving the URL in a "data availability" notification message and downloading the file. 
 * There is no requirement for a Global Cache to provide a "browse-able" interface to the files in its repository allowing Data Consumers to discover what content is available. However, a Global Cache may choose to provide such a capability (e.g., implemented as a "Web Accessible Folder", or WAF) along with adequate documentation for Data Consumers to understand how the capability works.
-* A Global Cache maintains the list of IP addresses used for outgoing connections to WIS nodes in the Global Registry. The Global Cache must announce changes to these IP addresses at least one month before implementing these changes.
+* When establishing a TLS connection to a WIS2 node, the Global Cache shall use the certificate issued by the Global Registry as a client certificate. 
+* When establishing a TLS connection to a WIS2 node, the Global Cache should validate the WIS2 node server certificate and check that it matches the hostname.
 
 TODO: to be completed
 
@@ -125,8 +126,8 @@ TODO: to be completed
 
 * The role of the Global Registry is to make available the information required for Global Services and WIS nodes to connect with each other. 
 * The Global Registry makes available to Global Brokers the list of registered WIS Nodes. The following metadata is made available for each WIS Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
-* The Global Registry makes available to WIS nodes the list of IP addresses used by Global Brokers and Global Caches to subscribe to and download data from WIS nodes.
-* The Global Registry provides authorized contacts the means to update information about their WIS Node or Global Services.
+* The Global Registry issues X.509 certificates to all GBs and GCs and periodically renews them.
+* The Global Registry maintains a certificate revokation list.
 * The Global Registry makes information available in such a way that minimizes the downtime of WIS nodes in case of changes to a node's metadata.
 
 ==== Service level

--- a/guide/sections/global-services.adoc
+++ b/guide/sections/global-services.adoc
@@ -21,8 +21,8 @@ TODO: to be completed
 * There will be multiple Global Broker instances to ensure highly available, low latency global provision of messages within WIS.
 * A Global Broker instance subscribes to messages from NC/DCPCs and other Global Brokers
 * A Global Broker instance will subscribe to messages from a subset of NC/DCPCs and republish them.
-** A Global Broker obtains the following list of metadata fields for each of the WIS2 nodes in the subset of NC/DCPCs covered by this Global Broker, from the Global Registry: Hostname and port(s) of broker, center_id, list of supported protocols (MQTT, MQTTs, web-socket). 
-** A Global Broker uses the username/password combination "everyone/everyone" to subscribe to the topic corresponding to the WIS2 node using one of the supported protocols.
+** A Global Broker obtains the following list of metadata fields for each of the WIS nodes in the subset of NC/DCPCs covered by this Global Broker, from the Global Registry: Hostname and port(s) of broker, center_id, list of supported protocols (MQTT, MQTTs, web-socket). 
+** A Global Broker uses the username/password combination "everyone/everyone" to subscribe to the topic corresponding to the WIS node using one of the supported protocols.
 * At least one Global Broker will subscribe to messages from every NC/DCPC.
 * For full global coverage, a Global Broker instance will subscribe to messages from other Global Broker instances and republish them.
 * A Global Broker instance will republish a message only once – noting that a particular message may be received multiple times (e.g., from different sources). Discarding duplicate messages is referred to as "anti-loop".
@@ -33,13 +33,13 @@ TODO: to be completed
 * A Global Broker is built around two software components:
 ** An off the shelf broker implementing both MQTT 3.1.1 and MQTT 5.0 in a highly-available setup (cluster)Tools such as EMQX, HiveMQ, VerneMQ are compliant with these requirements.
 ** Additional features (anti-loop, message format compliance,…) are required. An open source implementation will be made available during the pilot phase.
-* A Global Broker maintains the list of IP addresses used for outgoing subscription connections to WIS2 nodes in the Global Registry. The Global Broker must announce changes to these IP addresses at least one month before implementing these changes.
+* A Global Broker maintains the list of IP addresses used for outgoing subscription connections to WIS nodes in the Global Registry. The Global Broker must announce changes to these IP addresses at least one month before implementing these changes.
 
 TODO: to be completed
 
 ==== Practices and procedures
 
-The following procedures will be described here once validated through testing during the WIS2 pilot phase:
+The following procedures will be described here once validated through testing during the WIS pilot phase:
 
 * Assigning a Global Broker to a NC or DCPC
 * Alerting originating NC or DCPC about malformed or non-compliant messages
@@ -62,7 +62,7 @@ TODO: to be completed
 * A Global Cache will store a full set of discovery metadata records. This is not an additional metadata catalogue that Data Consumers can search and browse – it provides a complete set of discovery metadata records to support populating a Global Discovery Catalogue instance.
 * A Global Cache is designed to support real-time distribution of content. Data Consumers access data objects from a Global Cache instance by resolving the URL in a "data availability" notification message and downloading the file. 
 * There is no requirement for a Global Cache to provide a "browse-able" interface to the files in its repository allowing Data Consumers to discover what content is available. However, a Global Cache may choose to provide such a capability (e.g., implemented as a "Web Accessible Folder", or WAF) along with adequate documentation for Data Consumers to understand how the capability works.
-* A Global Cache maintains the list of IP addresses used for outgoing connections to WIS2 nodes in the Global Registry. The Global Cache must announce changes to these IP addresses at least one month before implementing these changes.
+* A Global Cache maintains the list of IP addresses used for outgoing connections to WIS nodes in the Global Registry. The Global Cache must announce changes to these IP addresses at least one month before implementing these changes.
 
 TODO: to be completed
 
@@ -123,11 +123,11 @@ TODO: to be completed
 
 === Global Registry ===
 
-* The role of the Global Registry is to make available the information required for Global Infrastructure and WIS2 nodes to connect with each other. 
-* The Global Registry makes available to Global Caches the list of registered WIS2 Nodes. The following metadata is made available for each WIS2 Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
-* The Global Registry makes available to WIS2 nodes the list of IP addresses used by Global Brokers and Global Caches to subscribe to and download data from WIS2 nodes.
-* The Global Registry provides authorized contacts the means to update information about their WIS2 Node or Global Infrastrucure.
-* The Global Registry makes information available in such a way that minimizes the downtime of WIS2 nodes in case of changes to a node's metadata.
+* The role of the Global Registry is to make available the information required for Global Infrastructure and WIS nodes to connect with each other. 
+* The Global Registry makes available to Global Caches the list of registered WIS Nodes. The following metadata is made available for each WIS Node: hostname and port(s) of local broker, center_id, list of implemented protocols (MQTT, MQTTs, web-socket).
+* The Global Registry makes available to WIS nodes the list of IP addresses used by Global Brokers and Global Caches to subscribe to and download data from WIS nodes.
+* The Global Registry provides authorized contacts the means to update information about their WIS Node or Global Infrastrucure.
+* The Global Registry makes information available in such a way that minimizes the downtime of WIS nodes in case of changes to a node's metadata.
 
 ==== Service level
 

--- a/guide/sections/wis2node.adoc
+++ b/guide/sections/wis2node.adoc
@@ -2,11 +2,17 @@
 
 === Practices and procedures
 
-==== Registration and decommissioning of a WIS node
+==== Registration and decommissioning of a WIS2 node
 
-This section describes the process used to register or remove a WIS node within WIS2. During the initial part of the WIS2 pilot phase, a Member simply needs to notify the WMO Secretariat and primary GISC of the intent to register a new WIS node. The Secretariat and GISC will then assist in the registration. More formal procedures will be developed as the number of WIS nodes increases.
+This section describes the process used to register or remove a WIS2 node within WIS2. To register one or more WIS nodes, the Member responside for the node needs to be designated as a NC or DCPC.
 
-TODO: To be completed
+An NC or DCPC can register new WIS2 nodes by submitting node metadata to the Gloabl Registry. 
+
+An NC or DCPC can remove an existing WIS2 node by removing the node from the Gloabl Registry. 
+
+An NC or DCPC can update WIS2 node metadata by editing the corresponding entry in the Gloabl Registry.
+
+National Focal points for WIS have the authority to change WIS2 node entries for the country which designated them, in the Global Registry.
 
 ==== Registration and removal of a Dataset
 
@@ -16,9 +22,11 @@ TODO: to be completed
 
 ==== Connecting with Global Services
 
-This section describes the process by which a WIS node is registered with one or more Global Broker and Global Cache components.
+This section describes the process by which a WIS2 node is registered with one or more Global Broker and Global Cache components.
 
-TODO: to be completed
+A WIS2 node shall allow at least one Global Broker and Global Cache to connect to its local broker and web storage. For this, the WIS2 node shall allow the outgoing IP addresses used by the Global Broker and Global Cache to establish connections to broker and web-storage, and allow the Global Cache to subscribe to the topic corresponding to this WIS2 node using the username and password combination "everyone/everyone".
+
+The list of IP addresses used by Global Brokers and Caches can be obtained from the Global Registry. If a WIS2 node implements source IP filtering to grant a Global Broker and Global Cache access, it shall implement changes to its filterting within one month of the changes being published to the Global Registry.
 
 === Publishing data, discovery metadata, and notification messages
 

--- a/guide/sections/wis2node.adoc
+++ b/guide/sections/wis2node.adoc
@@ -4,7 +4,7 @@
 
 ==== Registration and decommissioning of a WIS node
 
-This section describes the process used to register or remove a WIS node within WIS. To register one or more WIS nodes, the Member responside for the node needs to be designated as a NC or DCPC.
+This section describes the process used to register or remove a WIS node within WIS. To register one or more WIS nodes, the Member responside for the node needs to be designated as a NC or DCPC by the PR of the Member.
 
 An NC or DCPC can register new WIS nodes by submitting node metadata to the Global Registry. 
 
@@ -24,7 +24,7 @@ TODO: to be completed
 
 This section describes the process by which a WIS node is registered with one or more Global Broker and Global Cache components.
 
-A WIS node shall allow at least one Global Broker and Global Cache to connect to its local broker and web storage. For this, the WIS node shall allow the outgoing IP addresses used by the Global Broker and Global Cache to establish connections to broker and web-storage, and allow the Global Cache to subscribe to the topic corresponding to this WIS node using the username and password combination "everyone/everyone".
+A WIS node shall allow at least two Global Brokers to connect to its local broker and at least two Global Caches to its and web storage. For this, the WIS node shall allow the outgoing IP addresses used by the Global Broker and Global Cache to establish connections to broker and web-storage, and allow the Global Broker to subscribe to the topic corresponding to this WIS node using the username and password combination "everyone/everyone".
 
 The list of IP addresses used by Global Brokers and Caches can be obtained from the Global Registry. If a WIS node implements source IP filtering to grant a Global Broker and Global Cache access, it shall implement changes to its filterting within one month of the changes being published to the Global Registry.
 

--- a/guide/sections/wis2node.adoc
+++ b/guide/sections/wis2node.adoc
@@ -24,7 +24,7 @@ TODO: to be completed
 
 This section describes the process by which a WIS node is registered with one or more Global Broker and Global Cache components.
 
- * A WIS node shall allow at least two Global Brokers to connect to its local broker and at least two Global Caches to its and web storage. 
+ * A WIS node shall allow at least two Global Brokers to connect to its local broker and at least two Global Caches to its web storage. 
  * If a WIS node would like to restrict access to its broker or web-storage components it shall implement server-side TLS and use the client certificate supplied by Global Brokers and Global Caches for access control.
 
 === Publishing data, discovery metadata, and notification messages

--- a/guide/sections/wis2node.adoc
+++ b/guide/sections/wis2node.adoc
@@ -1,18 +1,18 @@
-== Implementation and operation of WIS2 Node
+== Implementation and operation of WIS Node
 
 === Practices and procedures
 
-==== Registration and decommissioning of a WIS2 node
+==== Registration and decommissioning of a WIS node
 
-This section describes the process used to register or remove a WIS2 node within WIS2. To register one or more WIS nodes, the Member responside for the node needs to be designated as a NC or DCPC.
+This section describes the process used to register or remove a WIS node within WIS. To register one or more WIS nodes, the Member responside for the node needs to be designated as a NC or DCPC.
 
-An NC or DCPC can register new WIS2 nodes by submitting node metadata to the Gloabl Registry. 
+An NC or DCPC can register new WIS nodes by submitting node metadata to the Global Registry. 
 
-An NC or DCPC can remove an existing WIS2 node by removing the node from the Gloabl Registry. 
+An NC or DCPC can remove an existing WIS node by removing the node from the Global Registry. 
 
-An NC or DCPC can update WIS2 node metadata by editing the corresponding entry in the Gloabl Registry.
+An NC or DCPC can update WIS node metadata by editing the corresponding entry in the Global Registry.
 
-National Focal points for WIS have the authority to change WIS2 node entries for the country which designated them, in the Global Registry.
+National Focal points for WIS have the authority to change WIS node entries for the country which designated them, in the Global Registry.
 
 ==== Registration and removal of a Dataset
 
@@ -22,11 +22,11 @@ TODO: to be completed
 
 ==== Connecting with Global Services
 
-This section describes the process by which a WIS2 node is registered with one or more Global Broker and Global Cache components.
+This section describes the process by which a WIS node is registered with one or more Global Broker and Global Cache components.
 
-A WIS2 node shall allow at least one Global Broker and Global Cache to connect to its local broker and web storage. For this, the WIS2 node shall allow the outgoing IP addresses used by the Global Broker and Global Cache to establish connections to broker and web-storage, and allow the Global Cache to subscribe to the topic corresponding to this WIS2 node using the username and password combination "everyone/everyone".
+A WIS node shall allow at least one Global Broker and Global Cache to connect to its local broker and web storage. For this, the WIS node shall allow the outgoing IP addresses used by the Global Broker and Global Cache to establish connections to broker and web-storage, and allow the Global Cache to subscribe to the topic corresponding to this WIS node using the username and password combination "everyone/everyone".
 
-The list of IP addresses used by Global Brokers and Caches can be obtained from the Global Registry. If a WIS2 node implements source IP filtering to grant a Global Broker and Global Cache access, it shall implement changes to its filterting within one month of the changes being published to the Global Registry.
+The list of IP addresses used by Global Brokers and Caches can be obtained from the Global Registry. If a WIS node implements source IP filtering to grant a Global Broker and Global Cache access, it shall implement changes to its filterting within one month of the changes being published to the Global Registry.
 
 === Publishing data, discovery metadata, and notification messages
 

--- a/guide/sections/wis2node.adoc
+++ b/guide/sections/wis2node.adoc
@@ -24,9 +24,8 @@ TODO: to be completed
 
 This section describes the process by which a WIS node is registered with one or more Global Broker and Global Cache components.
 
-A WIS node shall allow at least two Global Brokers to connect to its local broker and at least two Global Caches to its and web storage. For this, the WIS node shall allow the outgoing IP addresses used by the Global Broker and Global Cache to establish connections to broker and web-storage, and allow the Global Broker to subscribe to the topic corresponding to this WIS node using the username and password combination "everyone/everyone".
-
-The list of IP addresses used by Global Brokers and Caches can be obtained from the Global Registry. If a WIS node implements source IP filtering to grant a Global Broker and Global Cache access, it shall implement changes to its filterting within one month of the changes being published to the Global Registry.
+ * A WIS node shall allow at least two Global Brokers to connect to its local broker and at least two Global Caches to its and web storage. 
+ * If a WIS node would like to restrict access to its broker or web-storage components it shall implement server-side TLS and use the client certificate supplied by Global Brokers and Global Caches to for access control.
 
 === Publishing data, discovery metadata, and notification messages
 

--- a/guide/sections/wis2node.adoc
+++ b/guide/sections/wis2node.adoc
@@ -25,7 +25,7 @@ TODO: to be completed
 This section describes the process by which a WIS node is registered with one or more Global Broker and Global Cache components.
 
  * A WIS node shall allow at least two Global Brokers to connect to its local broker and at least two Global Caches to its and web storage. 
- * If a WIS node would like to restrict access to its broker or web-storage components it shall implement server-side TLS and use the client certificate supplied by Global Brokers and Global Caches to for access control.
+ * If a WIS node would like to restrict access to its broker or web-storage components it shall implement server-side TLS and use the client certificate supplied by Global Brokers and Global Caches for access control.
 
 === Publishing data, discovery metadata, and notification messages
 


### PR DESCRIPTION
Alternative option to allow WIS nodes to restrict access based on X.509 certificates. Same as #26,  but without source IP and username/password.
 
Instead: 
*  Global Registry issues certificates to GBs and GCs
 * GBs and GCs shall send a client certificate **if** they make a TLS connection to a WIS node
 * WIS nodes **can** use the client certificate to implement access control 
 * some provisions about a possible validation by GC/GB of server side certificates of WIS nodes

Thus, if a WIS node wants to restrict access to GBs/GCs only, it shall implement server side TLS and can then use the client certificate sent by GBs/GCs to implement ACLs.

Note: the approach works with load-balancer/firewall terminated TLS as well as broker/web-storage terminated ones.

[More detailed discussion comparing source IP/user&pw/certificates for WIS Node ACLs](https://github.com/wmo-im/wis2-guide/files/12537248/Managing.authentication.metadata.in.the.Global.Registry.docx)
