### PR TITLE
Updating "how to download data"

### DIFF
--- a/guide/sections/part1/data-consumer.adoc
+++ b/guide/sections/part1/data-consumer.adoc
@@ -28,7 +28,7 @@ Each Global Cache will publish a "data availability" message as the associated d
 
 ==== How to download data
 
-Dataset links are made available through Dataset discovery metadata (via the Global Discovery Catalogue) as well as data notification messages (via Global Brokers). Links can be used to directly download the data (according to the network protocol and content description provided in the link) using a mechanism appropriate to the workflow of the Data Consumer. This could include web and/or desktop applications, custom tooling, or other approaches.  For data subscriptions, data notification messages provide a "canonical" link (identified using the ``rel=``` link relation property) to download the associated data object.
+Dataset links are made available through Dataset discovery metadata (via the Global Discovery Catalogue) as well as data notification messages (via Global Brokers). Links can be used to directly download the data (according to the network protocol and content description provided in the link) using a mechanism appropriate to the workflow of the Data Consumer. This could include web and/or desktop applications, custom tooling, or other approaches.  For data subscriptions, data notification messages provide a "canonical" link (identified using the ``rel=`` link relation property) to download the associated data object.
 
 ==== Additional sections of interest to a Data Consumer (TODO: fix crossref)
 

--- a/guide/sections/part1/data-consumer.adoc
+++ b/guide/sections/part1/data-consumer.adoc
@@ -28,7 +28,7 @@ Each Global Cache will publish a "data availability" message as the associated d
 
 ==== How to download data
 
-Dataset links are made available through Dataset discovery metadata (via the Global Discovery Catalogue) as well as data notification messages (via Global Brokers). Links can be used to directly download the data (according to the network protocol and content description provided in the link) using a mechanism appropriate to the workflow of the Data Consumer. This could include web and/or desktop applications, custom tooling, or other approaches.  For data subscriptions, data notification messages provide a "cannonical" link to download the associated data object.
+Dataset links are made available through Dataset discovery metadata (via the Global Discovery Catalogue) as well as data notification messages (via Global Brokers). Links can be used to directly download the data (according to the network protocol and content description provided in the link) using a mechanism appropriate to the workflow of the Data Consumer. This could include web and/or desktop applications, custom tooling, or other approaches.  For data subscriptions, data notification messages provide a "canonical" link (identified using the ``rel=``` link relation property) to download the associated data object.
 
 ==== Additional sections of interest to a Data Consumer (TODO: fix crossref)
 


### PR DESCRIPTION
Fixed spelling mistake for "canonical"; clarified how the canonical link is identified.