### PR TITLE
New content for section: WIS2 Architecture.

### DIFF
--- a/guide/sections/part2/wis2-architecture.adoc
+++ b/guide/sections/part2/wis2-architecture.adoc
@@ -2,11 +2,15 @@
 
 WIS 2.0 is a federated system of systems based on Web-Architecture and open standards, comprising of many WIS2 Nodes for publishing data and Global Services that enable fault tolerant, highly available, low latency data distribution.
 
-National Centres (NC) and Data Collection and Production Centres (DCPC) operate WIS2 Nodes.   
+National Centres (NC), Data Collection and Production Centres (DCPC), and Global Information System Centres (GISC) are sll types of WIS Centre.
 
-In addition, Global Information System Centres (GISC) coordinate the operation of WIS within their Area of Responsibility (AoR) and ensure the smooth operation of the WIS 2.0 system.
+NCs and DCPCs operate WIS2 Nodes.   
 
-WIS2 Nodes, GISCs and Global Services are types of WIS Centre and comply with the Technical Regulations defined in the Manual on WIS (WMO No. 1060), Vol II.
+GISCs coordinate the operation of WIS within their Area of Responsibility (AoR) and ensure the smooth operation of the WIS 2.0 system. 
+
+A WIS Centre may also operate one or more Global Services.
+
+WIS Centres shall comply with the Technical Regulations defined in the Manual on WIS (WMO No. 1060), Vol I.2.
 
 ==== Roles in WIS 2.0
 
@@ -27,7 +31,7 @@ When describing the functions of WIS2 there are four roles to consider:
 
 . Global Service operator:
 * To ensure highly available global data exchange, a WIS Centre may operate one or more Global Services – 
-  i) Global Discovery Catalogue: enables users (humans and software agents) to search all Datasets provided by Data Publishers and discover where and how to interact with those Datasets (e.g., subscribe to updates, access/download/visualize data, or access more detailed information about the Dataset).
+  i) Global Discovery Catalogue: enables users to search all Datasets provided by Data Publishers and discover where and how to interact with those Datasets (e.g., subscribe to updates, access/download/visualize data, or access more detailed information about the Dataset).
   ii) Global Broker: provides highly available messaging services where users may subscribe to notifications about all Datasets provided by Data Publishers.
   iii) Global Cache: provides highly available download service for cached copies of core data downloaded from Data Publishers’ Web-services.
   iv) Global Monitor: gathers and displays system performance, data availability, and other metrics from all WIS nodes and Global Services.
@@ -66,7 +70,8 @@ When describing the functions of WIS2 there are four roles to consider:
 * A Global Cache subscribes to notification messages via a Global Broker.
 * On receipt of a notification message, the Global Cache downloads from the WIS2 Node a copy data referenced in the notification message, makes this copy available on its data server, and publishes a new notification message advertising availability of this data at the Global Cache.
 * A Global Cache will subscribe to notification messages from other Global Caches enabling it to download and republish data it has not acquired directly from WIS2 Nodes. This ensures that each Global Cache holds data from every WIS2 Node.
-* A Global Cache will delete data from the cache once the retention period has expired. The retention period is 24-hours.
+* A Global Cache shall retain a copy of core data for a duration compatible with the real-time or near real-time schedule of the data and not less than 24-hours.
+* A Global Cache will delete data from the cache once the retention period has expired.
 * Data Consumers should download data from a Global Cache when available.
 
 . Global Discovery Catalogue:

--- a/guide/sections/part2/wis2-architecture.adoc
+++ b/guide/sections/part2/wis2-architecture.adoc
@@ -1,7 +1,86 @@
-=== WIS2 Architecture
+===WIS 2.0 Architecture
 
-// include::sections/data-and-metadata-flows.adoc[]
+WIS 2.0 is a federated system of systems based on Web-Architecture and open standards, comprising of many WIS2 Nodes for publishing data and Global Services that enable fault tolerant, highly available, low latency data distribution.
 
-// include::sections/real-time-data-exchange.adoc[]
+National Centres (NC) and Data Collection and Production Centres (DCPC) operate WIS2 Nodes.   
 
-// include::sections/discovery-metadata.adoc[]
+In addition, Global Information System Centres (GISC) coordinate the operation of WIS within their Area of Responsibility (AoR) and ensure the smooth operation of the WIS 2.0 system.
+
+WIS2 Nodes, GISCs and Global Services are types of WIS Centre and comply with the Technical Regulations defined in the Manual on WIS (WMO No. 1060), Vol II.
+
+==== Roles in WIS 2.0
+
+When describing the functions of WIS2 there are four roles to consider:
+
+. Data Publisher: 
+* This role is fulfilled by NC and DCPC.
+* Data Publishers operate a "WIS node" to share their data within the WIS2 ecosystem.
+* Data Publishers manage, curate, and provide access to one or more "Datasets".
+* For each Dataset, a Data Publisher provides: 
+  i) "Discovery metadata" to describe the Dataset, provide details on how it can be accessed, and under what conditions.
+  ii) An API or Web-service to access (or interact with) the Dataset.
+  iii) Notification messages advertising the availability of new data and metadata.
+
+. Global Coordinator: 
+* This role is exclusive to GISCs.
+* All GISCs supporting WMO Members in their AoR fulfil their data sharing obligations via WIS2.
+
+. Global Service operator:
+* To ensure highly available global data exchange, a WIS Centre may operate one or more Global Services – 
+  i) Global Discovery Catalogue: enables users (humans and software agents) to search all Datasets provided by Data Publishers and discover where and how to interact with those Datasets (e.g., subscribe to updates, access/download/visualize data, or access more detailed information about the Dataset).
+  ii) Global Broker: provides highly available messaging services where users may subscribe to notifications about all Datasets provided by Data Publishers.
+  iii) Global Cache: provides highly available download service for cached copies of core data downloaded from Data Publishers’ Web-services.
+  iv) Global Monitor: gathers and displays system performance, data availability, and other metrics from all WIS nodes and Global Services.
+
+. Data Consumer:
+* This role represents anyone wanting to find, access, and use data from WIS2 – examples include (but are not limited to): NMHS, government agency, research institution, private sector organisation, etc.
+* Searches or browses the Global Discovery Catalogue (or other search engine) to discover the Dataset(s) that meet their needs (i.e., "Datasets of interest").
+* Subscribes via the Global Broker to receive notification messages about the availability of data or metadata associated with Datasets of interest.
+* Determines whether the data or metadata referenced in notification messages is required.
+* Downloads data from Global Cache or WIS2 Node.
+
+==== Components of WIS 2.0
+
+[TODO: add refs to other parts of the Guide describing these components]
+
+. WIS2 Node:
+* WIS2 Nodes are central to WIS 2.0. These are operated by National Centres (NC) and Data Collection and Production Centres (DCPC) to publish their *Core* and *Recommended* data.
+* WIS 2.0 adopts Web technologies and open standards enabling WIS2 Nodes to be implemented using freely-available software components and common industry practices.
+* WIS2 Nodes publish data as files of a Web server or using an interactive Web service.
+* WIS2 Nodes describe the data they publish using discovery metadata [TODO: ref. WIS Core Metadata Profile 2].
+* WIS2 Nodes generate notification messages [TODO: ref. WIS2 Notification Message] advertising the availability of new data. These notification messages are published to a message broker. A standardised topic hierarchy [TODO: ref. WIS2 Topic Hierarchy] is used to ensure that all WIS2 Nodes publish to consistent topics. The information in the notification message tells the Data Consumer where to download data from. Notification messages are also used to advertise the availability of discovery metadata.
+* WIS2 Nodes may implement controlled access for the data they publish. Global Services will operate with fixed IP addresses, enabling WIS2 Nodes to easily distinguish their requests.
+ 
+. Global Broker:
+* WIS2 incorporates several Global Brokers, ensuring highly resilient distribution of notification messages across the globe.
+* A Global Broker subscribes to the message broker operated by each WIS2 Node and republishes notification messages. 
+* A Global broker subscribes to notifications from other Global Brokers to ensure it receives a copy of all notification messages. 
+* A Global Broker republishes notification messages from every WIS2 Node and Global Service.
+* A Global Broker operates a highly available, high-performance message broker.
+* A Global Broker uses the standardised topic hierarchy enabling a Data Consumer to easily find topics relevant to their needs.
+* Data Consumers should subscribe to notifications from a Global Broker not directly to the message brokers operated by WIS2 Nodes.
+
+. Global Cache:
+* WIS2 incorporates several Global Caches, ensuring highly resilient distribution of data across the globe.
+* A Global Cache provides a highly available data server from which a Data Consumer can download Core data, as specified in the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021)).
+* A Global Cache subscribes to notification messages via a Global Broker.
+* On receipt of a notification message, the Global Cache downloads from the WIS2 Node a copy data referenced in the notification message, makes this copy available on its data server, and publishes a new notification message advertising availability of this data at the Global Cache.
+* A Global Cache will subscribe to notification messages from other Global Caches enabling it to download and republish data it has not acquired directly from WIS2 Nodes. This ensures that each Global Cache holds data from every WIS2 Node.
+* A Global Cache will delete data from the cache once the retention period has expired. The retention period is 24-hours.
+* Data Consumers should download data from a Global Cache when available.
+
+. Global Discovery Catalogue:
+* WIS2 includes several Global Discovery Catalogues.
+* A Global Discovery Catalogue enables a data consumer to search and browse descriptions of data published by each WIS2 Node. The data description (i.e., discovery metadata) provides sufficient information to determine the usefulness of data and how one may access it.
+* A Global Discovery Catalogue subscribes to notification messages via a Global Broker about the availability of new (or updated) discovery metadata. It downloads a copy of the discovery metadata and updates the catalogue.
+* A Global Discovery Catalogue will amend discovery metadata records to add details of where one can subscribe to updates about the Dataset at a Global Broker.
+* A Global Discovery Catalogue makes its content available for indexing by search engines.
+
+. Global Monitor:
+* WIS2 includes a Global Monitor service.
+* The Global Monitor collects metrics from WIS2 components.
+* The Global Monitor provides a dashboard that supports operational management of the WIS2 system. 
+* The Global Monitor tracks: 
+  i) What data is published by WIS2 Nodes.
+  ii) Whether data can be effectively accessed by Data Consumers.
+  iii) The performance of components in the WIS2 system.


### PR DESCRIPTION
Written to provide a high-level overview of things important to WIS2: roles and components.

References to the following resources are removed:
* sections/data-and-metadata-flows.adoc
* sections/real-time-data-exchange.adoc
* sections/discovery-metadata.adoc

I think these are no longer needed given the revamp of the Guide.