### PR TITLE
Added requirement that GBs authenticate on subscription to WIS Nodes …

### DIFF
--- a/guide/sections/part2/global-services.adoc
+++ b/guide/sections/part2/global-services.adoc
@@ -82,7 +82,7 @@ In the following sections and for each Global Service, a set of metrics is defin
 * A Global Broker instance subscribes to messages from WIS Centres and other Global Services. The Global Broker should aim at subscribing to all WIS Centres. If this is not possible, for whatever reason, the Global Broker should inform WMO Secretariat so that situation is documented.
 * Every WIS Centre or Global Service must have subscriptions from at least two Global Brokers.
 * For full global coverage, a Global Broker instance will subscribe to messages from at least two (2) other Global Brokers.
-* When subscribing to messages from WIS Centres and other Global Services, a Global Broker must authenticate using the valid credentials provided by WMO Secretariat. 
+* When subscribing to messages from WIS Centres and other Global Services, a Global Broker must authenticate using the valid credentials managed by the WIS Centre and available at WMO Secretariat.
 
 * A Global Broker is built around two software components:
 ** An off the shelf broker implementing both MQTT 3.1.1 and MQTT 5.0 in a highly-available setup, typically in a cluster mode. Tools such as EMQX, HiveMQ, VerneMQ, RabbitMQ (in its latest versions) are compliant with these requirements. It must be noted that the open source version of Mosquitto cannot be clustered and therefore should not be used as part of a Global Broker.

--- a/guide/sections/part2/global-services.adoc
+++ b/guide/sections/part2/global-services.adoc
@@ -79,9 +79,10 @@ In the following sections and for each Global Service, a set of metrics is defin
 ===== Technical considerations
 
 * As detailed above, there will be at least three (3) instances of Global Broker to ensure highly available, low latency global provision of messages within WIS.
-* A Global Broker instance subscribes to messages from WIS Centres, Global Caches and other Global Brokers. The Global Broker should aim at subscribing to all WIS Centres. If this is not possible, for whatever reason, the Global Broker should inform WMO Secretariat so that situation is documented.
+* A Global Broker instance subscribes to messages from WIS Centres and other Global Services. The Global Broker should aim at subscribing to all WIS Centres. If this is not possible, for whatever reason, the Global Broker should inform WMO Secretariat so that situation is documented.
 * Every WIS Centre or Global Service must have subscriptions from at least two Global Brokers.
 * For full global coverage, a Global Broker instance will subscribe to messages from at least two (2) other Global Brokers.
+* When subscribing to messages from WIS Centres and other Global Services, a Global Broker must authenticate using the valid credentials provided by WMO Secretariat. 
 
 * A Global Broker is built around two software components:
 ** An off the shelf broker implementing both MQTT 3.1.1 and MQTT 5.0 in a highly-available setup, typically in a cluster mode. Tools such as EMQX, HiveMQ, VerneMQ, RabbitMQ (in its latest versions) are compliant with these requirements. It must be noted that the open source version of Mosquitto cannot be clustered and therefore should not be used as part of a Global Broker.


### PR DESCRIPTION
…and other Global Services

Also - changed "GC and other GBs" to "other Global Services" ... we now have GDC's publishing notifications too (for publication of the metadata archive resource) and soon, everyone will be publishing notifications for monitoring purposes.

@golfvert - please can you validate?

Issue #74 refers. 

I've not written everyone/everyone here - and I've also not been explicit that each WIS2 Node might have unique credentials.