### PR TITLE
add GHA to generate all unique channels from all GDCs

### DIFF
--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -3,10 +3,10 @@ name: Generate list of all GDC channels
 
 on: [pull_request]
 
-on:
-  schedule:
-    #- cron: '0 * * * *'  # runs every hour
-    - cron: '* * * * *'  # runs every minute, for debugging
+#on:
+#  schedule:
+#    #- cron: '0 * * * *'  # runs every hour
+#    - cron: '* * * * *'  # runs every minute, for debugging
 
 env:
   FILEPATH: /tmp/gdc-all-channels-latest.txt

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -1,5 +1,9 @@
 name: Generate list of all GDC channels
 
+
+on:
+  pull_request:
+
 on:
   schedule:
     #- cron: '0 * * * *'  # runs every hour

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -1,8 +1,7 @@
 name: Generate list of all GDC channels
 
 
-on:
-  pull_request:
+on: [pull_request]
 
 on:
   schedule:

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -1,6 +1,5 @@
 name: Generate list of all GDC channels
 
-
 on: [pull_request]
 
 #on:
@@ -39,7 +38,7 @@ jobs:
         git checkout gh-pages
         git config --global user.email "tomkralidis@gmail.com"
         git config --global user.name "Tom Kralidis"
-        mv -f ${FILEPATH}
+        mv -f ${FILEPATH} .
         git add .
         git commit -am "update GDC all channels"
         git push

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install requirements 📦
       run: |
-        pip3 install requests
+        pip3 install -r scripts/requirements.txt
     - name: generate unique channels
       run: |
         python3 scripts/generate-gdc-all-channels.py > ${FILEPATH}

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -27,16 +27,16 @@ jobs:
     - name: generate unique channels
       run: |
         python3 scripts/generate-gdc-all-channels.py > ${FILEPATH}
-      - name: checkout gh-pages branch
-        uses: actions/checkout@master
-        with:
-          ref: gh-pages
-      - name: update gh-pages branch and publish
-        run: | 
-          git checkout gh-pages
-          git config --global user.email "tomkralidis@gmail.com"
-          git config --global user.name "Tom Kralidis"
-          mv -f ${FILEPATH}
-          git add .
-          git commit -am "update GDC all channels"
-          git push
+    - name: checkout gh-pages branch
+      uses: actions/checkout@master
+      with:
+        ref: gh-pages
+    - name: update gh-pages branch and publish
+      run: | 
+        git checkout gh-pages
+        git config --global user.email "tomkralidis@gmail.com"
+        git config --global user.name "Tom Kralidis"
+        mv -f ${FILEPATH}
+        git add .
+        git commit -am "update GDC all channels"
+        git push

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -1,0 +1,42 @@
+name: Generate list of all GDC channels
+
+on:
+  schedule:
+    #- cron: '0 * * * *'  # runs every hour
+    - cron: '* * * * *'  # runs every minute, for debugging
+
+env:
+  FILEPATH: /tmp/gdc-all-channels-latest.txt
+
+jobs:
+  generate-gdc-all-channels:
+    name: Generate all unique channels from all WIS2 GDCs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v5
+      name: Setup Python ${{ matrix.python-version }}
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install requirements 📦
+      run: |
+        pip3 install requests
+    - name: generate unique channels
+      run: |
+        python3 scripts/generate-gdc-all-channels.py > ${FILEPATH}
+      - name: checkout gh-pages branch
+        uses: actions/checkout@master
+        with:
+          ref: gh-pages
+      - name: update gh-pages branch and publish
+        run: | 
+          git checkout gh-pages
+          git config --global user.email "tomkralidis@gmail.com"
+          git config --global user.name "Tom Kralidis"
+          mv -f ${FILEPATH}
+          git add .
+          git commit -am "update GDC all channels"
+          git push

--- a/.github/workflows/gdc-all-channels.yml
+++ b/.github/workflows/gdc-all-channels.yml
@@ -1,11 +1,9 @@
 name: Generate list of all GDC channels
 
-on: [pull_request]
-
-#on:
-#  schedule:
-#    #- cron: '0 * * * *'  # runs every hour
-#    - cron: '* * * * *'  # runs every minute, for debugging
+on:
+  schedule:
+    - cron: '0 * * * *'  # runs every hour
+    # - cron: '* * * * *'  # runs every minute, for debugging
 
 env:
   FILEPATH: /tmp/gdc-all-channels-latest.txt

--- a/scripts/generate-gdc-all-channels.py
+++ b/scripts/generate-gdc-all-channels.py
@@ -33,19 +33,24 @@ GDCS = [
     # 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata'
 ]
 
-params = {
+CHANNELS = (
+    'cache/a/wis2',
+    'origin/a/wis2'
+)
+
+PARAMS = {
     'f': 'json',
     'limit': 100000
 }
 
 for gdc in GDCS:
     url = f'{gdc}/items'
-    response = requests.get(url, params=params).json()
+    response = requests.get(url, params=PARAMS).json()
 
     for feature in response['features']:
         for link in feature['links']:
             channel = link.get('channel')
-            if channel is not None:
+            if channel is not None and channel.startswith(CHANNELS):
                 channel = channel.replace('cache/a/wis2/', '').replace('origin/a/wis2/', '')  # noqa
                 ALL_CHANNELS.append(channel)
 

--- a/scripts/generate-gdc-all-channels.py
+++ b/scripts/generate-gdc-all-channels.py
@@ -1,0 +1,53 @@
+###############################################################################
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2025 Tom Kralidis
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+
+import requests
+
+ALL_CHANNELS = []
+
+GDCS = [
+    'https://wis2-gdc.weather.gc.ca/collections/wis2-discovery-metadata',
+    'https://wis2.dwd.de/gdc/collections/wis2-discovery-metadata',
+    # 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata'
+]
+
+params = {
+    'f': 'json',
+    'limit': 100000
+}
+
+for gdc in GDCS:
+    url = f'{gdc}/items'
+    response = requests.get(url, params=params).json()
+
+    for feature in response['features']:
+        for link in feature['links']:
+            channel = link.get('channel')
+            if channel is not None:
+                channel = channel.replace('cache/a/wis2/', '').replace('origin/a/wis2/', '')  # noqa
+                ALL_CHANNELS.append(channel)
+
+for channel in set(ALL_CHANNELS):
+    print(channel)

--- a/scripts/generate-gdc-all-channels.py
+++ b/scripts/generate-gdc-all-channels.py
@@ -49,5 +49,5 @@ for gdc in GDCS:
                 channel = channel.replace('cache/a/wis2/', '').replace('origin/a/wis2/', '')  # noqa
                 ALL_CHANNELS.append(channel)
 
-for channel in set(ALL_CHANNELS):
+for channel in sorted(set(ALL_CHANNELS)):
     print(channel)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Implementation per https://wmo-im.github.io/wis2-guide/guide/wis2-guide-APPROVED.html#_2_7_3_1_technical_considerations

> A Global Broker will check if a discovery metadata record exists corresponding to the topic on which a message has been published. If there is no corresponding discovery metadata record, the Global Broker will discard non-compliant messages and will raise an alert. The metric wmo_wis2_gb_messages_no_metadata_total will be increased by 1. The Global Broker should not request information from a Global Discovery Catalogue for each notification message but should keep a cache of all valid topics for every centre-id.