### PR TITLE
output list by WCMP2 id

### DIFF
--- a/scripts/generate-gdc-all-channels.py
+++ b/scripts/generate-gdc-all-channels.py
@@ -49,10 +49,10 @@ for gdc in GDCS:
 
     for feature in response['features']:
         for link in feature['links']:
-            channel = link.get('channel')
-            if channel is not None and channel.startswith(CHANNELS):
-                channel = channel.replace('cache/a/wis2/', '').replace('origin/a/wis2/', '')  # noqa
-                ALL_CHANNELS.append(channel)
+            channel = link.get('channel', '')
+            if channel.startswith(CHANNELS):
+                channel = '/'.join(channel.split('/')[4:])
+                ALL_CHANNELS.append(','.join([feature['id'], channel]))
 
 for channel in sorted(set(ALL_CHANNELS)):
     print(channel)


### PR DESCRIPTION
Sample output is now organized by WCMP2 id, e.g.:

```csv
urn:wmo:md:us-noaa-nws:surface-based-observations-uz-temp,data/core/surface-based-observations/temp
urn:wmo:md:us-noaa-nws:surface-weather-observations:synop,data/core/weather/surface-based-observations/synop
urn:wmo:md:vc-metservice:core.surface-based-observations.synop,data/core/weather/surface-based-observations/synop
urn:wmo:md:vg-metservice:core.surface-based-observations.synop,data/core/weather/surface-based-observations/synop
urn:wmo:md:zm-zmd:core.surface-based-observations.synop,data/core/weather/surface-based-observations/synop
```