### PR TITLE
Add outage notification guideline for Global Services

### DIFF
--- a/guide/sections/part2/global-services.adoc
+++ b/guide/sections/part2/global-services.adoc
@@ -47,6 +47,7 @@ The full set of the WIS2 monitoring metrics is given in WMO: WIS2 Metric Hierarc
 * Each WIS centre operating a WIS2 Node is responsible for achieving the highest possible level of service based on its resources and capabilities.
 * All Global Services, in particular Global Brokers and Global Caches, are collectively responsible for making WIS a reliable and efficient means of exchanging the data required for the operation of all WIS centres. The architecture provides a redundant solution where the failure of one component will not impact the overall level of service of WIS.
 * Each Global Service should aim to achieve at least 99.5% availability of the service it provides. This is not a contractual target. It should be considered by the entity providing the Global Service as a guideline when designing and operating that service.
+* Any Global Service operator anticipating an outage that may exceed 4 hours should notify other WIS2 centres (including other Global Services and the WMO Secretariat) in advance to allow them to prepare for the disruption.
 * A Global Broker:
 ** Should support a minimum of 200 WIS2 Nodes or Global Services;
 ** Should support a minimum of 1 000 subscribers;


### PR DESCRIPTION
Added a guideline for notifying WIS2 centres about outages exceeding 4 hours.