### PR TITLE
Refine subscription and processing steps for Sensor Centre

### DIFF
--- a/guide/sections/part3/sensor-centres.adoc
+++ b/guide/sections/part3/sensor-centres.adoc
@@ -93,7 +93,16 @@ As a Global Cache can decide not to cache a data granule, and in order to assess
 
 If no Global Cache has cached the data, increase by 1 `wmo_wis2_scgc_messages_missed_all_total`
 
-All the metrics must be exposed for scraping by the Global Monitor.
+All the metrics SHALL be exposed for scraping by the Global Monitor.
+
+In addition to the metrics, the SCGC will also make available an hourly logfile containing at least:
+- the centre-id 
+- the full topic where the WIS2 Notification Message has been originally published
+- the full WIS2 Notification Message as published by the origin centre-id
+- for each Global Cache a clear indication when the message pertaining to this data-id has been published on the cache topic (the timestamp), and if the data-id was not republished by a particular Global Cache `9999999999999` will be used instead of the timestamp
+- each entry in the log file will be a valid JSON 
+
+Then, at the end of the hour, the SCGC SHALL publish a notification message on `monitor/a/wis2/{tld}-{centre-name}-sensor-centre-global-cache` providing a URL to download the logfile. The notification message published will be conformant with the WMO WIS2 Monitoring Events specifications. The `type`used SHALL be `int.wmo.wis.wme.event.item.download`.
 
 ==== 3.3.4 Sensor Centres for Global Discovery Catalogues (SCGDC)
 

--- a/guide/sections/part3/sensor-centres.adoc
+++ b/guide/sections/part3/sensor-centres.adoc
@@ -102,7 +102,7 @@ In addition to the metrics, the SCGC will also make available an hourly logfile 
 * for each Global Cache a clear indication when the message pertaining to this data-id has been published on the cache topic (the timestamp), and if the data-id was not republished by a particular Global Cache `9999999999999` will be used instead of the timestamp
 * each entry in the log file will be a valid JSON 
 
-Then, at the end of the hour, the SCGC SHALL publish a notification message on `monitor/a/wis2/{tld}-{centre-name}-sensor-centre-global-cache` providing a URL to download the logfile. The notification message published will be conformant with the WMO WIS2 Monitoring Events specifications. The `type`used SHALL be `int.wmo.wis.wme.event.item.download`.
+Then, at the end of the hour, the SCGC SHALL publish a notification message on `monitor/a/wis2/{tld}-{centre-name}-sensor-centre-global-cache` providing a URL to download the logfile. The notification message published will be conformant with the WMO WIS2 Monitoring Events specifications. The monitor message will be of `type` : `int.wmo.wis.wme.event.item.download`.
 
 ==== 3.3.4 Sensor Centres for Global Discovery Catalogues (SCGDC)
 

--- a/guide/sections/part3/sensor-centres.adoc
+++ b/guide/sections/part3/sensor-centres.adoc
@@ -96,6 +96,7 @@ If no Global Cache has cached the data, increase by 1 `wmo_wis2_scgc_messages_mi
 All the metrics SHALL be exposed for scraping by the Global Monitor.
 
 In addition to the metrics, the SCGC will also make available an hourly logfile containing at least:
+
 * the centre-id 
 * the full topic where the WIS2 Notification Message has been originally published
 * the full WIS2 Notification Message as published by the origin centre-id

--- a/guide/sections/part3/sensor-centres.adoc
+++ b/guide/sections/part3/sensor-centres.adoc
@@ -71,10 +71,9 @@ A list of metrics has been defined for this Sensor Centre at https://github.com/
 
 The processing of this Sensor Centre is as follows:
 
-- Subscribe to a given `origin/a/wis2/...`, it could be `#` or a particular centre-id on at least one Global Broker
-- Subscribe to a given `cache/a/wis2/...`, it could be `#` or a particular centre-id on at least one Global Cache - The subscription must be done on the broker of the Global Cache (unlike normal subscription to be made only on the Global Broker)
+- Subscribe to a given `origin/a/wis2/...` and to the equivalent on the cache topic (`cache/a/wis2/...`). The last subscription level could be `#` or a particular centre-id or any subtopic.
 
-Only on the subscription to the Global Broker:
+For the messages received on the `origin` topic subscription:
 
 - Discard the Notification Message if is it `recommended` data as it will not be cached
 - Detect any duplicates `data_id` not including a `rel: update` within a period of at least 3 hours
@@ -82,12 +81,13 @@ Only on the subscription to the Global Broker:
 - Store the time where the message as been received
 - (optional) Store the full Notification Message - this can be useful to analyse systematic issues
 
-For each of the subscription to the various Global Caches:
+For the messages received on the `cache` topic subscription and using the `properties.global-cache`value to select the Global Cache:
 
-- For each Notification Message and using `data_id`, make the difference between the time was received on `origin` and the same `data_id` on `cache`: Time~Cache~ - Time~Origin~
-- Update the `wmo_wis2_scgc_cache_delay_seconds` metric with this value
-- Compare this value with the three threshold defined in the metric table above. Increase by 1 `wmo_wis2_scgc_messages_cached_delay_total` using the threshold as a label (so less than 120s, less that 300s, less than 600s)
-- If no Notification Message for the `data_id` is received after the highest threshold (here 600s), increase by 1 `wmo_wis2_scgc_messages_missed_total`
+- Check if the link with `rel="canonical` or `rel="update"` in `links` is reachable by doing a HTTP HEAD request (The HTTP HEAD must provide a response status code equal to `200`). If this is not the case, discard the Notification Message. Otherwise:
+  - For each Notification Message and using `data_id`, make the difference between the time was received on `origin` and the same `data_id` on `cache`: Time~Cache~ - Time~Origin~
+  - Update the `wmo_wis2_scgc_cache_delay_seconds` metric with this value
+  - Compare this value with the three threshold defined in the metric table above. Increase by 1 `wmo_wis2_scgc_messages_cached_delay_total` using the threshold as a label (so less than 120s, less that 300s, less than 600s)
+- If no Notification Message for the `data_id` is received after the highest threshold (here 600s) or if the link provided is not valid, increase by 1 `wmo_wis2_scgc_messages_missed_total`
 
 As a Global Cache can decide not to cache a data granule, and in order to assess if a Global Cache has decided to do so, the Sensor Centre will compare the ``links`` array published on `++origin/a/wis/#++` and in the Notification Message received on `++cache/a/wis2/#++` if the two ``links`` are identical, then the Global Cache has decided not to cache the data. In this case, increase by 1 ``wmo_wis2_scgc_messages_cache_override_total``.
 

--- a/guide/sections/part3/sensor-centres.adoc
+++ b/guide/sections/part3/sensor-centres.adoc
@@ -71,23 +71,23 @@ A list of metrics has been defined for this Sensor Centre at https://github.com/
 
 The processing of this Sensor Centre is as follows:
 
-- Subscribe to a given `origin/a/wis2/...` and to the equivalent on the cache topic (`cache/a/wis2/...`). The last subscription level could be `#` or a particular centre-id or any subtopic.
+* Subscribe to a given `origin/a/wis2/...` and to the equivalent on the cache topic (`cache/a/wis2/...`). The last subscription level could be `#` or a particular centre-id or any subtopic.
 
 For the messages received on the `origin` topic subscription:
 
-- Discard the Notification Message if is it `recommended` data as it will not be cached
-- Detect any duplicates `data_id` not including a `rel: update` within a period of at least 3 hours
-- Increase by 1 `wmo_wis2_scgc_messages_published_total` metrics
-- Store the time where the message as been received
-- (optional) Store the full Notification Message - this can be useful to analyse systematic issues
+* Discard the Notification Message if is it `recommended` data as it will not be cached
+* Detect any duplicates `data_id` not including a `rel: update` within a period of at least 3 hours
+* Increase by 1 `wmo_wis2_scgc_messages_published_total` metrics
+* Store the time where the message as been received
+* (optional) Store the full Notification Message - this can be useful to analyse systematic issues
 
 For the messages received on the `cache` topic subscription and using the `properties.global-cache`value to select the Global Cache:
 
-- Check if the link with `rel="canonical` or `rel="update"` in `links` is reachable by doing a HTTP HEAD request (The HTTP HEAD must provide a response status code equal to `200`). If this is not the case, discard the Notification Message. Otherwise:
-  - For each Notification Message and using `data_id`, make the difference between the time was received on `origin` and the same `data_id` on `cache`: Time~Cache~ - Time~Origin~
-  - Update the `wmo_wis2_scgc_cache_delay_seconds` metric with this value
-  - Compare this value with the three threshold defined in the metric table above. Increase by 1 `wmo_wis2_scgc_messages_cached_delay_total` using the threshold as a label (so less than 120s, less that 300s, less than 600s)
-- If no Notification Message for the `data_id` is received after the highest threshold (here 600s) or if the link provided is not valid, increase by 1 `wmo_wis2_scgc_messages_missed_total`
+* Check if the link with `rel="canonical` or `rel="update"` in `links` is reachable by doing a HTTP HEAD request (The HTTP HEAD must provide a response status code equal to `200`). If this is not the case, discard the Notification Message. Otherwise:
+  ** For each Notification Message and using `data_id`, make the difference between the time was received on `origin` and the same `data_id` on `cache`: Time~Cache~ - Time~Origin~
+  ** Update the `wmo_wis2_scgc_cache_delay_seconds` metric with this value
+  ** Compare this value with the three threshold defined in the metric table above. Increase by 1 `wmo_wis2_scgc_messages_cached_delay_total` using the threshold as a label (so less than 120s, less that 300s, less than 600s)
+* If no Notification Message for the `data_id` is received after the highest threshold (here 600s) or if the link provided is not valid, increase by 1 `wmo_wis2_scgc_messages_missed_total`
 
 As a Global Cache can decide not to cache a data granule, and in order to assess if a Global Cache has decided to do so, the Sensor Centre will compare the ``links`` array published on `++origin/a/wis/#++` and in the Notification Message received on `++cache/a/wis2/#++` if the two ``links`` are identical, then the Global Cache has decided not to cache the data. In this case, increase by 1 ``wmo_wis2_scgc_messages_cache_override_total``.
 
@@ -96,11 +96,11 @@ If no Global Cache has cached the data, increase by 1 `wmo_wis2_scgc_messages_mi
 All the metrics SHALL be exposed for scraping by the Global Monitor.
 
 In addition to the metrics, the SCGC will also make available an hourly logfile containing at least:
-- the centre-id 
-- the full topic where the WIS2 Notification Message has been originally published
-- the full WIS2 Notification Message as published by the origin centre-id
-- for each Global Cache a clear indication when the message pertaining to this data-id has been published on the cache topic (the timestamp), and if the data-id was not republished by a particular Global Cache `9999999999999` will be used instead of the timestamp
-- each entry in the log file will be a valid JSON 
+* the centre-id 
+* the full topic where the WIS2 Notification Message has been originally published
+* the full WIS2 Notification Message as published by the origin centre-id
+* for each Global Cache a clear indication when the message pertaining to this data-id has been published on the cache topic (the timestamp), and if the data-id was not republished by a particular Global Cache `9999999999999` will be used instead of the timestamp
+* each entry in the log file will be a valid JSON 
 
 Then, at the end of the hour, the SCGC SHALL publish a notification message on `monitor/a/wis2/{tld}-{centre-name}-sensor-centre-global-cache` providing a URL to download the logfile. The notification message published will be conformant with the WMO WIS2 Monitoring Events specifications. The `type`used SHALL be `int.wmo.wis.wme.event.item.download`.
 


### PR DESCRIPTION
Now that all GC include the properties.global-cache, the text can be amended. And based on the suggestion from ET-WISOP on May 18th, add a check of the provided link.